### PR TITLE
Updat keymap in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ EOF
 
 | Keymap    | Action                                     |
 |-----------|--------------------------------------------|
-| `e`       | Edit task under cursor                     |
+| `ee`      | Edit task under cursor                     |
 | `dd`      | Delete task under cursor                   |
 | `<space>` | Toggles task under cursor as done/not done |
 | `m`       | Toggle metadata for task                   |


### PR DESCRIPTION
The readme specifies `e` as the keymap for editing task, but the default keymap is `ee`.